### PR TITLE
Use one as default when block file has no version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import * as program from "commander";
 import * as inquirer from "inquirer";
 
+import * as packageFile from "../package.json";
 import { cloneBoilerplate } from "./commands/cloneBoilerplate";
 import { login } from "./commands/login";
 import {
@@ -15,7 +16,7 @@ import {
 import { getCategoryNames, logError, logInfo } from "./utils";
 
 program
-    .version("1.0.0", "-v, --version")
+    .version(packageFile.version, "-v, --version")
     .usage(`[options] command`)
     .option("-V, --verbose", "Display verbose output")
     .description("Command line interface for the Volusion Element ecosystem");

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -10,7 +10,7 @@ export interface BlockFileObject {
     id: string;
     isPublic: boolean;
     publishedName: string;
-    activeVersion: number;
+    activeVersion?: number;
     git?: boolean;
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

For blocks created with the cli v1, the `activeVersion` property is not defined in the block file. We need to make sure that is always sent to the server. This PR fixes those cases.


* **What is the current behavior?**

Not sending the `activeVersion` flag when needed.
