### PR TITLE
[V2-2788] block name should be required

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -19,6 +19,12 @@ export const validateInputs = (
     category: string,
     categories?: string[]
 ): { displayName: string; publishedName: string } => {
+    // Commander sends `name` as a function if user does not
+    // provide the name
+    if (typeof name === "function") {
+        logError("The block name is required (-n option).");
+        exit(1);
+    }
     if (!category) {
         logError("Please select or enter a category name.");
         exit(1);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?**

No validation of block name presence generates an error when publishing without it.


* **What is the new behavior (if this is a feature change)?**

Validates that the name of a block is required when publishing it.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
