### PR TITLE
[V2-3630] always have block id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion LLC",
   "main": "bin/src/index.js",

--- a/src/commands/cloneBoilerplate.ts
+++ b/src/commands/cloneBoilerplate.ts
@@ -6,6 +6,7 @@ import * as rimraf from "rimraf";
 import { BLOCK_SETTINGS_FILE } from "../constants";
 import {
     cloneRepo,
+    createBlockId,
     createBlockSettingsFile,
     gitInit,
     logError,
@@ -57,6 +58,8 @@ const cloneBoilerplate = async (name: string, git: boolean): Promise<void> => {
 
     try {
         await cloneRepo(BOILERPLATE_LOCATION, name);
+        const blockIdRes = await createBlockId();
+        const blockId = blockIdRes.data.blockId;
 
         logInfo(`Saved boilerplate to ./${name}; now updating...`);
 
@@ -69,7 +72,7 @@ const cloneBoilerplate = async (name: string, git: boolean): Promise<void> => {
 
         const updatedFiles: string[] = await updateModuleNames(name);
 
-        await createBlockSettingsFile(name, git);
+        await createBlockSettingsFile(name, git, blockId);
 
         logSuccess(`Updated files ${updatedFiles.join(", ")}!`);
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -33,7 +33,7 @@ const publish = async (
     validateFilesExistOrExit();
     validateNotAlreadyPublishedOrExit();
 
-    const { displayName, publishedName } = validateInputs(
+    const { displayName, publishedName, id } = validateInputs(
         name,
         category,
         categories
@@ -45,6 +45,7 @@ const publish = async (
 
     try {
         const res: AxiosResponse = await createBlockRequest(
+            id,
             {
                 displayName,
                 publishedName,
@@ -61,6 +62,7 @@ const publish = async (
             displayName,
             id: res.data.id,
             isPublic: false,
+            published: true,
         });
 
         if (git) {
@@ -167,6 +169,7 @@ const update = async (
         updateBlockSettingsFile({
             activeVersion: version,
             isPublic: publicFlag,
+            published: true,
         });
 
         if (git) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,6 @@ program
             newMajorVersion();
         } else {
             const categories = await getCategoryNames();
-
             if (category) {
                 publish(name, category, categories);
             } else {

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -8,8 +8,10 @@ export interface BlockFileObject {
     category?: string;
     displayName: string;
     id: string;
+    idFromStart?: boolean; // Since v.2.0.8
     isPublic: boolean;
     publishedName: string;
+    published?: boolean; // Since v.2.0.8
     activeVersion?: number;
     git?: boolean;
 }
@@ -25,12 +27,19 @@ const writeFileUtil = (path: string, data: any): void => {
     }
 };
 
-export const createBlockSettingsFile = (name: string, git: boolean): void => {
+export const createBlockSettingsFile = (
+    name: string,
+    git: boolean,
+    id: string
+): void => {
     const displayName = formatName(name);
 
     const data = JSON.stringify({
+        activeVersion: 1,
         displayName,
         git,
+        id,
+        idFromStart: true, // Since v.2.0.8
         publishedName: name,
     });
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,7 @@ export { formatName, toPascalCase } from "./formatting";
 export { prepareImage } from "./images";
 export { checkErrorCode, logError, logInfo, logSuccess, logWarn } from "./log";
 export {
+    createBlockId,
     createBlockRequest,
     createMajorBlockRequest,
     getBlockRequest,

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -55,6 +55,7 @@ const requestOptions = (
 const buildRequestConfig = ({
     category,
     fileData,
+    id,
     isPublic = false,
     method = "POST",
     names,
@@ -62,6 +63,7 @@ const buildRequestConfig = ({
     url,
     note = "",
 }: {
+    id?: string;
     category?: string;
     fileData: string;
     isPublic?: boolean;
@@ -81,6 +83,7 @@ const buildRequestConfig = ({
         ...options,
         data: {
             content: fileData,
+            id,
             metadata: {
                 category,
                 isPublic,
@@ -110,10 +113,19 @@ const buildSimpleRequestConfig = ({
     };
 };
 
+export const createBlockId = (): AxiosPromise =>
+    axios(
+        buildSimpleRequestConfig({
+            method: "POST",
+            url: `${config.blockRegistry.host}/blocks/blockId`,
+        })
+    );
+
 export const getBlockRequest = (id: string): AxiosPromise =>
     axios(requestOptions("GET", `${config.blockRegistry.host}/blocks/${id}`));
 
 export const createBlockRequest = (
+    id: string,
     names: {
         displayName: string;
         publishedName: string;
@@ -125,6 +137,7 @@ export const createBlockRequest = (
         buildRequestConfig({
             category,
             fileData,
+            id,
             method: "POST",
             names,
             url: `${config.blockRegistry.host}/blocks`,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -18,7 +18,7 @@ export const validateInputs = (
     name: string | null,
     category: string,
     categories?: string[]
-): { displayName: string; publishedName: string } => {
+): { displayName: string; publishedName: string; id: string } => {
     // Commander sends `name` as a function if user does not
     // provide the name
     if (typeof name === "function") {
@@ -42,16 +42,18 @@ export const validateInputs = (
     const nameFromDotfile = readBlockSettingsFile(BLOCK_SETTINGS_FILE)
         .displayName;
     const displayName = formatName(name || nameFromDotfile);
-    const publishedName = readBlockSettingsFile(BLOCK_SETTINGS_FILE)
-        .publishedName;
+    const { publishedName, id } = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
 
-    return { displayName, publishedName };
+    return { displayName, publishedName, id };
 };
 
 export const validateNotAlreadyPublishedOrExit = (): void => {
     const fileContents = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
 
-    if (!!fileContents.id) {
+    if (
+        (!!fileContents.id && !fileContents.idFromStart) ||
+        (fileContents.idFromStart && fileContents.published)
+    ) {
         logError(
             "This block has already been published to staging. Please try running the `update` command to update the contents of this block or run the `release` command to push your block live."
         );


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

We want to always have the id of the block, even before publishing it for the first time to have proper and consistent naming conventions.

* **What is the current behavior?**

The block id is generated after publishing. This force us to use a block naming convention with published name for the first version, and if for the next versions.

* **What is the new behavior (if this is a feature change)?**

When creating a new block, an id will be generated and will be preserved during the life of the block. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:

Current users should update the CLI.
