### PR TITLE
V2E-659 cant switch block versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion LLC",
   "main": "bin/src/index.js",

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -83,8 +83,6 @@ const newMajorVersion = async (): Promise<void> => {
     validateBlockExistOrExit();
 
     const filePath = resolve(cwd(), BUILT_FILE_PATH);
-    const blockData = readFileSync(filePath).toString();
-    const minifiedCode = uglify.minify(blockData).code;
     const { activeVersion, displayName, id } = readBlockSettingsFile(
         BLOCK_SETTINGS_FILE
     );
@@ -97,6 +95,9 @@ const newMajorVersion = async (): Promise<void> => {
         });
 
         await execAsyc("npm run build");
+
+        const blockData = readFileSync(filePath).toString();
+        const minifiedCode = uglify.minify(blockData).code;
 
         const res: AxiosResponse = await createMajorBlockRequest(
             minifiedCode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { getCategoryNames, logError, logInfo } from "./utils";
 
 program
-    .version("3.0.1", "-v, --version")
+    .version("3.0.2", "-v, --version")
     .usage(`[options] command`)
     .option("-V, --verbose", "Display verbose output")
     .description("Command line interface for the Volusion Element ecosystem");


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix when publishing the bundle of a new major version. 


* **What is the current behavior?**

We read the contents of the current bundle, then run `npm run build`, and send to the server the contents of the previous bundle. That's the error. We need to read the contents of the bundle **after** we build.


* **What is the new behavior (if this is a feature change)?**

Read the contents of the bundle after the build has finished, not before.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.


* **Other information**:

None.