### PR TITLE
[V2E-1050] do not clone repo on block id failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2460,8 +2460,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2482,14 +2481,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2504,20 +2501,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2634,8 +2628,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2647,7 +2640,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2662,7 +2654,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2670,14 +2661,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2696,7 +2685,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2786,8 +2774,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2799,7 +2786,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2885,8 +2871,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2922,7 +2907,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2942,7 +2926,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2986,14 +2969,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/src/commands/cloneBoilerplate.ts
+++ b/src/commands/cloneBoilerplate.ts
@@ -56,8 +56,8 @@ const cloneBoilerplate = async (name: string): Promise<void> => {
     }
 
     try {
-        await cloneRepo(BOILERPLATE_LOCATION, name);
         const blockIdRes = await createBlockId();
+        await cloneRepo(BOILERPLATE_LOCATION, name);
         const blockId = blockIdRes.data.blockId;
 
         logInfo(`Saved boilerplate to ./${name}; now updating...`);
@@ -78,6 +78,7 @@ const cloneBoilerplate = async (name: string): Promise<void> => {
         exit(0);
     } catch (err) {
         logError(err);
+        logInfo("Hint: Try `element login` before running this command again.");
         exit(1);
     }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { getCategoryNames, logError, logInfo } from "./utils";
 
 program
-    .version("3.0.4", "-v, --version")
+    .version("3.0.5", "-v, --version")
     .usage(`[options] command`)
     .option("-V, --verbose", "Display verbose output")
     .description("Command line interface for the Volusion Element ecosystem");


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

If getting a new block id fails, do not create incomplete boilerplate.


* **What is the current behavior?**

If the endpoint for getting a new block id fails as a result of a not authorized, it will create an incomplete block folder which generates issues later.

* **What is the new behavior (if this is a feature change)?**

First get the id, if it fails, do not clone the block starter repo.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

