### PR TITLE
add username and password options to element login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,24 +29,34 @@ const log = console.log;
 
 program
     .command("login")
-    .description("Log in using your Volusion credentials")
-    .action(() => {
+    .description(
+        `Log in using your Volusion credentials
+                    [-u, --username USERNAME]
+                    [-p, --password PASSWORD]`
+    )
+    .option("-u, --username [username]", "Volusion username")
+    .option("-p, --password [password]", "Volusion password")
+    .action(({ username, password }) => {
+        const prompts = [];
+        if (!username) {
+            prompts.push({
+                message: "Enter your username",
+                name: "user",
+                type: "input",
+            });
+        }
+        if (!password) {
+            prompts.push({
+                message: "Enter your password",
+                name: "pass",
+                type: "password",
+            });
+        }
         inquirer
-            .prompt([
-                {
-                    message: "Enter your username",
-                    name: "username",
-                    type: "input",
-                },
-                {
-                    message: "Enter your password",
-                    name: "password",
-                    type: "password",
-                },
-            ])
+            .prompt(prompts)
             .then((val: any) => {
-                const { username, password } = val;
-                login(username, password);
+                const { user, pass } = val;
+                login(user || username, pass || password);
             })
             .catch(logError);
     });
@@ -62,7 +72,9 @@ program
     .command("publish")
     .description(
         `Publish a block to the Block Theme Registry
-                    [-n, --name NAME] [-c, --category CATEGORY] [-m, --major-version]
+                    [-n, --name NAME]
+                    [-c, --category CATEGORY]
+                    [-m, --major-version]
                     Suggestion: Keep your screenshots under 500 kb
                                 and aim for more of a rectangle than
                                 a square.`

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,10 @@ program
     .description(
         `Log in using your Volusion credentials
                     [-u, --username USERNAME]
-                    [-p, --password PASSWORD]`
+                    [-p, --password PASSWORD]
+                        You may need to wrap your password in single quotes
+                        and\\or escape special characters with a backslash \\
+                        Keep in mind that using a password in the terminal can be insecure.`
     )
     .option("-u, --username [username]", "Volusion username")
     .option("-p, --password [password]", "Volusion password")
@@ -41,22 +44,22 @@ program
         if (!username) {
             prompts.push({
                 message: "Enter your username",
-                name: "user",
+                name: "usernameInput",
                 type: "input",
             });
         }
         if (!password) {
             prompts.push({
                 message: "Enter your password",
-                name: "pass",
+                name: "passwordInput",
                 type: "password",
             });
         }
         inquirer
             .prompt(prompts)
             .then((val: any) => {
-                const { user, pass } = val;
-                login(user || username, pass || password);
+                const { usernameInput, passwordInput } = val;
+                login(username || usernameInput, password || passwordInput);
             })
             .catch(logError);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { getCategoryNames, logError, logInfo } from "./utils";
 
 program
-    .version("3.0.5", "-v, --version")
+    .version("3.0.6", "-v, --version")
     .usage(`[options] command`)
     .option("-V, --verbose", "Display verbose output")
     .description("Command line interface for the Volusion Element ecosystem");


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    + [ ] Tests for the changes have been added (for bug fixes / features)
    + [X] Docs have been added / updated (for bug fixes / features)
    + [ ] Addresses [Github issue #n](https://github.com/volusion/element-cli/issues/n) (please replace `n` with the corresponding issue number -- no issue for this PR? You can create one [here](https://github.com/volusion/element-cli/issues/new) right quick! 🙏 )


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add options to `login` for username and password.

* **What is the current behavior?**

Prompts for username and then prompts for password

* **What is the new behavior (if this is a feature change)?**

No option to pass username and password with the login command so have to go through prompts.

```bash
element login -u test@test.com -p yourPassword
```

You may decide to only prompt for password.

```bash
element login -u test@test.com
```

Original behavior remains the same.

```bash
element login
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
