### PR TITLE
remove unnecessary publishing validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,13 @@ npm install -g @volusion/element-cli
 
 The command for logging into the Element ecosystem. This is necessary for publishing and updating [blocks](https://github.com/volusion/element-tutorial#vocabulary).
 
-Use the same credentials you use to log into your [Volusion store admin](https://admin.volusion.com).
+Use the same credentials you use to log into your [Volusion store admin](https://admin.volusion.com). You may optionally pass in username from the command line:  `element --username email@email.com`
 
 * * *
 
-### `element new NAME --git`
+### `element new NAME`
 
 The command for scaffolding a new block. The command will clone the [Element Block Starter repo](https://github.com/volusion/element-blockstarter), allowing you to quickly get started with your development process. The NAME passed in will be converted to PascalCase.
-
-You can use the optional `--git` flag to let git handle your block commits and major versions.
 
 * * *
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -6,7 +6,7 @@ import { cwd, exit } from "process";
 import * as uglify from "uglify-js";
 import * as util from "util";
 
-const execAsyc = util.promisify(exec);
+const execAsync = util.promisify(exec);
 
 import {
     BLOCK_SETTINGS_FILE,
@@ -27,7 +27,6 @@ import {
     validateBlockExistOrExit,
     validateFilesExistOrExit,
     validateInputs,
-    validateNotAlreadyPublishedOrExit,
 } from "../utils";
 
 const publish = async (
@@ -36,7 +35,6 @@ const publish = async (
     categories?: string[]
 ): Promise<void> => {
     validateFilesExistOrExit();
-    validateNotAlreadyPublishedOrExit();
 
     const { displayName, publishedName, id } = validateInputs(
         name,
@@ -101,7 +99,7 @@ const newMajorVersion = async (): Promise<void> => {
             activeVersion: version,
         });
 
-        await execAsyc("npm run build");
+        await execAsync("npm run build");
 
         const blockData = readFileSync(filePath).toString();
         const minifiedCode = uglify.minify(blockData).code;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,7 @@ program
     .command("login")
     .description(
         `Log in using your Volusion credentials
-                    [-u, --username USERNAME]
-                    [-p, --password PASSWORD]
-                        You may need to wrap your password in single quotes
-                        and\\or escape special characters with a backslash \\
-                        Keep in mind that using a password in the terminal can be insecure.`
+                    [-u, --username USERNAME]`
     )
     .option("-u, --username [username]", "Volusion username")
     .option("-p, --password [password]", "Volusion password")

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,7 +23,6 @@ export {
     validateInputs,
     validateBlockExistOrExit,
     validateFilesExistOrExit,
-    validateNotAlreadyPublishedOrExit,
 } from "./validation";
 
 export { cloneRepo } from "./git";

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -47,20 +47,6 @@ export const validateInputs = (
     return { displayName, publishedName, id };
 };
 
-export const validateNotAlreadyPublishedOrExit = (): void => {
-    const fileContents = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
-
-    if (
-        (!!fileContents.id && !fileContents.idFromStart) ||
-        (fileContents.idFromStart && fileContents.published)
-    ) {
-        logError(
-            "This block has already been published to staging. Please try running the `update` command to update the contents of this block or run the `release` command to push your block live."
-        );
-        exit(1);
-    }
-};
-
 export const validateBlockExistOrExit = (): void => {
     const fileContents = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    + [ ] Tests for the changes have been added (for bug fixes / features)
    + [X] Docs have been added / updated (for bug fixes / features)
    + [ ] Addresses [Github issue #n](https://github.com/volusion/element-cli/issues/n) (please replace `n` with the corresponding issue number -- no issue for this PR? You can create one [here](https://github.com/volusion/element-cli/issues/new) right quick! 🙏 )


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Removes unnecessary validation to prevent a block from accidentally being published twice, as this is already handled on the server side.


* **What is the current behavior?**

Gives error message about block already being published.

* **What is the new behavior (if this is a feature change)?**

Gives the exact same error message, but it now comes from the server.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

Updates readme with information on a `login` command option and removes outdated documentation for the `new` command.