### PR TITLE
add categories, silent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,129 +1,20 @@
 # Element CLI
 
-The [command-line interface](https://en.wikipedia.org/wiki/Command-line_interface) for developing and managing building [blocks](https://github.com/volusion/element-tutorial) for the next generation of [Volusion](https://www.volusion.com) storefronts
+The Element command-line interface enables the development and management of [Element blocks](https://volusion.github.io/element/explanations/element-concepts) for the [Volusion Volt platform](https://www.volusion.com/volt).
 
-## Table of Contents
-
-- [Installing](#installing)
-- [Using the CLI](#using-the-cli)
-- [Developing for the CLI](#developing-for-the-cli)
-- [Built With](#built-with)
-- [Contributing](#contributing)
-- [Authors](#authors)
-- [License](#license)
-
-## Installing
-
-After [installing Node.js](https://nodejs.org/en/download/), run
-
-```bash
-npm install -g @volusion/element-cli
-```
-
-## Using the CLI
-
-### `element login`
-
-The command for logging into the Element ecosystem. This is necessary for publishing and updating [blocks](https://github.com/volusion/element-tutorial#vocabulary).
-
-Use the same credentials you use to log into your [Volusion store admin](https://admin.volusion.com). You may optionally pass in username from the command line:  `element --username email@email.com`
-
-* * *
-
-### `element new NAME`
-
-The command for scaffolding a new block. The command will clone the [Element Block Starter repo](https://github.com/volusion/element-blockstarter), allowing you to quickly get started with your development process. The NAME passed in will be converted to PascalCase.
-
-* * *
-
-### `element publish --name "A NAME TO DISPLAY TO USERS" --category "OPTIONAL CATEGORY" --major-version`
-
-From the root directory of the block you intend to eventually make available to users of the Site Designer on the [Volusion store admin](https://admin.volusion.com).
-
-Publishing your first block also will create a v1 branch to manage the version code base.
-
-By default, _newly-published blocks will only be visible to you and the other members of your organization_.
-
-In the event that a `-c/--category` flag is not passed, you will be prompted with a list of valid Category names from which to select. You may also call `element categories` to see the list of categories.
-
-If you pass `-m or --major-version` it will create a new major version for the block and a corresponding git branch.
-
-_Protip_: `element publish -n "A NAME TO DISPLAY TO USERS" -c "OPTIONAL CATEGORY"`
-_Protip_: `element publish -m`
-
-* * *
-
-### `element update`
-
-After you make changes to your block, and are ready test to them in the Site Designer, run this command from the root directory of the block. You'll likely run this command often.
-
-### `element update --toggle-public`
-
-There's only one optional flag for this command, and it's to make your initially-private block public, and available in the world.
-
-_Protip_: `element update -p`
-
-* * *
-
-### `element release`
-
-When you are ready to push your block live you can use this command.
-
-### `element release --note "release note for the block`
-
-There's only one optional flag for this command, and it's to add a release note to your block
-
-_Protip_: `element update -n "release note for the block"`
-
-* * *
-
-### `element rollback`
-
-If you have a problem with a release you can rollback to a previous release. The current release will be moved back to staging and the previous release will become active. If you rollback again it will remove the release from staging. You can continue to rollback until you only have your original release.
-
-Each major version can be rolled back individually. However, you won't be able to rollback the inital published major version of the block.
-
-* * *
-
-### `element categories`
-
-See a list of valid categories for your block.
-
-* * *
-
-### Adding a Thumbnail
-
-Create a PNG file, ideally less than 100 kb in size, and save it in the root directory of the block as `thumbnail.png.` When publishing or updating your block, this file will be saved and then be shown in the Volusion store admin's [Site Designer](https://admin.volusion.com/designer).
-
-### Getting CLI Help
-
-```bash
-element --help
-
-# Or for individual commands, e.g.
-element publish --help
-```
-
-## Developing for the CLI
-
-Please see the [DEVELOPING](./DEVELOPING.md) document for more information on the project requirements and workflow.
+Please see our [Element documentation](https://volusion.github.io/element/references/element-cli) to get started.
 
 ## Built With
 
 - [Commander](https://github.com/tj/commander.js) - User interaction framework 🖼
 - [Inquirer](https://github.com/SBoudrias/Inquirer.js) - Hidden fields 🙈 and fancy selections 💅
 - [Axios](https://github.com/axios/axios) - Making calls across the network ☎️
-- [Mermaid](https://github.com/mermaidjs/mermaid.cli) - Building the diagrams 🧜‍♀️ 🧜‍♂️
 
 ## Contributing
 
-We're very excited that you're interested in contributing! At present, we are working toward formalizing a process for providing feedback on and accepting pull requests. If you would like us to prioritize this process, please vote on [this open issue](https://github.com/volusion/element-cli/issues/1) with a 👍 . We do already have a [Code of Conduct](CODE_OF_CONDUCT.md) in place.
-
-## Code of Conduct
-
-Our Code of Conduct, by way of the Contributor Covenant, [can be found here](CODE_OF_CONDUCT.md).
+We're very excited that you're interested in contributing! At present, we are working toward formalizing a process for providing feedback on and accepting pull requests. If you would like us to prioritize this process, please vote on [this open issue](https://github.com/volusion/element-cli/issues/1) with a 👍 . We have a [Code of Conduct](CODE_OF_CONDUCT.md) in place and a [document on developing](DEVELOPING.md) for the CLI.
 
 ## License
 
-&copy; 2018 onward by Volusion
-[MIT License](LICENSE)
+[MIT License](LICENSE)\
+Copywrite &copy; 2018-present Volusion, LLC

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The command for scaffolding a new block. The command will clone the [Element Blo
 
 * * *
 
-### `element publish --name "A NAME TO DISPLAY TO USERS" --category "OPTIONAL CATEGORY" --new-major`
+### `element publish --name "A NAME TO DISPLAY TO USERS" --category "OPTIONAL CATEGORY" --major-version`
 
 From the root directory of the block you intend to eventually make available to users of the Site Designer on the [Volusion store admin](https://admin.volusion.com).
 
@@ -44,9 +44,9 @@ Publishing your first block also will create a v1 branch to manage the version c
 
 By default, _newly-published blocks will only be visible to you and the other members of your organization_.
 
-In the event that a `-c/--category` flag is not passed, you will be prompted with a list of valid Category names from which to select.
+In the event that a `-c/--category` flag is not passed, you will be prompted with a list of valid Category names from which to select. You may also call `element categories` to see the list of categories.
 
-If you pass `-m or --new-major` it will create a new major version for the block and a corresponding git branch.
+If you pass `-m or --major-version` it will create a new major version for the block and a corresponding git branch.
 
 _Protip_: `element publish -n "A NAME TO DISPLAY TO USERS" -c "OPTIONAL CATEGORY"`
 _Protip_: `element publish -m`
@@ -82,6 +82,12 @@ _Protip_: `element update -n "release note for the block"`
 If you have a problem with a release you can rollback to a previous release. The current release will be moved back to staging and the previous release will become active. If you rollback again it will remove the release from staging. You can continue to rollback until you only have your original release.
 
 Each major version can be rolled back individually. However, you won't be able to rollback the inital published major version of the block.
+
+* * *
+
+### `element categories`
+
+See a list of valid categories for your block.
 
 * * *
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -227,7 +227,7 @@ const rollback = async (): Promise<void> => {
         const res: AxiosResponse = await rollbackBlockRequest(id, version);
 
         logSuccess(`
-            Rollbacked ${displayName} v${version}
+            Rolled back ${displayName} v${version}
             ID ${res.data.id}
         `);
 


### PR DESCRIPTION
update command help and info messages

update readme

* **Please check if the PR fulfills these requirements**
    + [ ] Tests for the changes have been added (for bug fixes / features)
    + [X] Docs have been added / updated (for bug fixes / features)
    + [ ] Addresses [Github issue #n](https://github.com/volusion/element-cli/issues/n) (please replace `n` with the corresponding issue number -- no issue for this PR? You can create one [here](https://github.com/volusion/element-cli/issues/new) right quick! 🙏 )


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

features

* **What is the current behavior?**

The following commands give confirmation prompts:
```bash
element publish
element rollback
element release
```

The only way to view the list of valid categories is to call publish without specifying a category.

* **What is the new behavior (if this is a feature change)?**

  * Enables passing in a silent flag to skip confirmation prompts, in `publish`, `rollback`, and `release` commands.
  * Adds a `categories` command to get the list of valid categories

```bash
element categories
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:

- removes out-of-date information from the readme and links to the Element documentation.
- replaces any use of `console.log` or `console.error` in index.ts with the utility `logInfo` and `logError` functions respectively.