### PR TITLE
remove incrementing major version number on client side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 node_modules
 bin
 coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
 import { getCategoryNames, logError, logInfo } from "./utils";
 
 program
-    .version("3.0.9", "-v, --version")
+    .version("3.0.10", "-v, --version")
     .usage(`[options] command`)
     .option("-V, --verbose", "Display verbose output")
     .description("Command line interface for the Volusion Element ecosystem");

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -175,15 +175,13 @@ export const updateBlockRequest = (
 export const createMajorBlockRequest = (
     defaultConfig: { [key: string]: any },
     content: string,
-    id: string,
-    version: number
+    id: string
 ): AxiosPromise =>
     axios(
         buildSimpleRequestConfig({
             data: {
                 content,
                 defaultConfig,
-                version,
             },
             method: "POST",
             url: `${config.blockRegistry.host}/blocks/${id}/major`,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    + [ ] Tests for the changes have been added (for bug fixes / features)
    + [ ] Docs have been added / updated (for bug fixes / features)
    + [ ] Addresses [Github issue #n](https://github.com/volusion/element-cli/issues/n) (please replace `n` with the corresponding issue number -- no issue for this PR? You can create one [here](https://github.com/volusion/element-cli/issues/new) right quick! 🙏 )


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

update internal implementation to remove uneeded code.

* **What is the current behavior?**

CLI client is currently incrementing the major version number when publishing a major version. However, the server side is incrementing the version number so it is not necessary for the CLI to do this.

* **What is the new behavior (if this is a feature change)?**

No change in behavior.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
