### PR TITLE
add info command to retrieve block metadata from the server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
 } from "./utils";
 
 program
-    .version("3.0.10", "-v, --version")
+    .version("3.1.0", "-v, --version")
     .usage(`[options] command`)
     .option("-V, --verbose", "Display verbose output")
     .description("Command line interface for the Volusion Element ecosystem");

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
     getCategoryNames,
     logError,
     logInfo,
+    logWarn,
     readBlockSettingsFile,
 } from "./utils";
 
@@ -81,9 +82,15 @@ program
     });
 program
     .command("info")
-    .description("Block Metadata Info")
+    .description("View block metadata information from server")
     .action(async () => {
-        const { id } = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
+        const { id, published } = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
+        if (!published) {
+            logWarn(
+                "You must first publish your block to view server information."
+            );
+            process.exit(1);
+        }
         const block = await getBlockRequest(id).catch((err: Error) => {
             logError(err);
             process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,14 @@ import {
     rollback,
     update,
 } from "./commands/publish";
-import { getCategoryNames, logError, logInfo } from "./utils";
+import { BLOCK_SETTINGS_FILE } from "./constants";
+import {
+    getBlockRequest,
+    getCategoryNames,
+    logError,
+    logInfo,
+    readBlockSettingsFile,
+} from "./utils";
 
 program
     .version("3.0.10", "-v, --version")
@@ -71,6 +78,18 @@ program
     .action(async () => {
         const categories = await getCategoryNames();
         logInfo((categories || []).join("\n"));
+    });
+program
+    .command("info")
+    .description("Block Metadata Info")
+    .action(async () => {
+        const { id } = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
+        const block = await getBlockRequest(id).catch((err: Error) => {
+            logError(err);
+            process.exit(1);
+        });
+        logInfo("Block metadata:");
+        logInfo(JSON.stringify(block.data.metadata, null, 2));
     });
 
 program


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    + [ ] Tests for the changes have been added (for bug fixes / features)
    + [X] Docs have been added / updated (for bug fixes / features)
    + [ ] Addresses [Github issue #n](https://github.com/volusion/element-cli/issues/n) (please replace `n` with the corresponding issue number -- no issue for this PR? You can create one [here](https://github.com/volusion/element-cli/issues/new) right quick! 🙏 )


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature to retrieve block metadata from the server

* **What is the current behavior?**

There is no way to retrieve this information, which hinders debugging.

* **What is the new behavior (if this is a feature change)?**

Adds `info` command to retrieve block metadata from the server

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

Sample data returned:

![image](https://user-images.githubusercontent.com/22917554/84521854-4245cb00-ac9b-11ea-8ad8-fec4dfb5ac63.png)
