### PR TITLE
Major version elem block fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -107,19 +107,16 @@ const newMajorVersion = async (): Promise<void> => {
             minifiedCode,
             id
         );
-        const newVersion =
-            res.data.versions.reduce((accMax: any, item: any) => {
-                return item.isMajor ? Math.max(accMax, item.version) : accMax;
-            }, 1) || 1;
-
         logResponse(res);
 
+        const latestMajorVersion = getLatestMajorVersion(res.data.versions);
+
         updateBlockSettingsFile({
-            activeVersion: newVersion,
+            activeVersion: latestMajorVersion,
         });
 
         logSuccess(`
-            Published ${displayName} v${newVersion} for staging
+            Published ${displayName} v${latestMajorVersion} for staging
             ID ${res.data.id}
         `);
         exit(0);
@@ -268,6 +265,14 @@ const blockDetails = (): {
 };
 
 export { publish, update, release, rollback, blockDetails, newMajorVersion };
+
+function getLatestMajorVersion(versions: any[]): number {
+    return (
+        versions.reduce((accMax: any, item: any) => {
+            return item.isMajor ? Math.max(accMax, item.version) : accMax;
+        }, 1) || 1
+    );
+}
 
 async function runBuild(): Promise<void> {
     if (isVerbose) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,17 +98,21 @@ program
     .description("View block metadata information from server")
     .action(async () => {
         isLoggedInOrExit();
-        const { id, published } = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
+        const { activeVersion, id, published } = readBlockSettingsFile(
+            BLOCK_SETTINGS_FILE
+        );
         if (!published) {
             logWarn(
                 "You must first publish your block to view server information."
             );
             process.exit(1);
         }
-        const block = await getBlockRequest(id).catch((err: Error) => {
-            logError(err);
-            process.exit(1);
-        });
+        const block = await getBlockRequest(id, activeVersion).catch(
+            (err: Error) => {
+                logError(err);
+                process.exit(1);
+            }
+        );
         logInfo("Block metadata:");
         logInfo(JSON.stringify(block.data.metadata, null, 2));
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
 } from "./utils";
 
 program
-    .version("3.1.0", "-v, --version")
+    .version("3.1.1", "-v, --version")
     .usage(`[options] command`)
     .option("-V, --verbose", "Display verbose output")
     .description("Command line interface for the Volusion Element ecosystem");

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -68,7 +68,7 @@ const readFile = (path: string): string | undefined => {
 const createDataString = (latestData: UpdateData): string => {
     const currentData = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
     const updatedData = Object.assign({}, currentData, latestData);
-    return JSON.stringify(updatedData);
+    return JSON.stringify(updatedData, null, 2);
 };
 
 export const updateBlockSettingsFile = (latestData: UpdateData): void => {

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -124,15 +124,15 @@ export const createBlockId = (): AxiosPromise =>
         })
     );
 
-export const getBlockRequest = (id: string, version?: number): AxiosPromise =>
-    axios(
+export const getBlockRequest = (id: string, version?: number): AxiosPromise => {
+    const versionQueryString = version ? "?version=" + version : "";
+    return axios(
         requestOptions(
             "GET",
-            `${config.blockRegistry.host}/blocks/${id}${
-                version ? "?version=" + version : ""
-            }`
+            `${config.blockRegistry.host}/blocks/${id}${versionQueryString}`
         )
     );
+};
 
 export const createBlockRequest = (
     defaultConfig: { [key: string]: any },

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -125,11 +125,13 @@ export const createBlockId = (): AxiosPromise =>
     );
 
 export const getBlockRequest = (id: string, version?: number): AxiosPromise => {
-    const versionQueryString = version ? "?version=" + version : "";
+    const optionalVersionQueryString = version ? "?version=" + version : "";
     return axios(
         requestOptions(
             "GET",
-            `${config.blockRegistry.host}/blocks/${id}${versionQueryString}`
+            `${
+                config.blockRegistry.host
+            }/blocks/${id}${optionalVersionQueryString}`
         )
     );
 };

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -124,8 +124,15 @@ export const createBlockId = (): AxiosPromise =>
         })
     );
 
-export const getBlockRequest = (id: string): AxiosPromise =>
-    axios(requestOptions("GET", `${config.blockRegistry.host}/blocks/${id}`));
+export const getBlockRequest = (id: string, version?: number): AxiosPromise =>
+    axios(
+        requestOptions(
+            "GET",
+            `${config.blockRegistry.host}/blocks/${id}${
+                version ? "?version=" + version : ""
+            }`
+        )
+    );
 
 export const createBlockRequest = (
     defaultConfig: { [key: string]: any },


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    + [ ] Tests for the changes have been added (for bug fixes / features)
    + [ ] Docs have been added / updated (for bug fixes / features)
    + [ ] Addresses [Github issue #n](https://github.com/volusion/element-cli/issues/n) (please replace `n` with the corresponding issue number -- no issue for this PR? You can create one [here](https://github.com/volusion/element-cli/issues/new) right quick! 🙏 )


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- bug fix
- enhancement

* **What is the current behavior?**

- publishing a major version does not update the correct version in the `.element-block` file.
- need to remember to run `npm run build` before each command except `element publish --major-version`
- `element info` always requested version 1

* **What is the new behavior (if this is a feature change)?**

- after publishing a major version, it now correctly updates the `.element-block` file
- executes `npm run build` for each element action command
- passes version for `element info`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- no

* **Other information**:

- formats JSON in `.element-block` file
- outputs response from server with `--verbose`