### PR TITLE
add --skip-build and pass user-agent header

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # Default reviewers for everything in the repo.
 # Unless a later match takes precedence "*" = all
 
-* @santios-volusion @greg-murray-volusion
+* @santios-volusion @greg-murray-volusion @cameron-jones-volusion

--- a/config.ts
+++ b/config.ts
@@ -1,5 +1,8 @@
+import { ELEMENT_VERSION } from "./src/constants";
+
 interface Config {
     blockRegistry: { host: string };
+    userAgent: string;
 }
 
 interface AuthConfig {
@@ -31,6 +34,8 @@ const config: Config = {
             process.env.ELEMENT_BLOCK_REGISTRY_URI ||
             "https://btr.v2-prod.volusion.com",
     },
+    userAgent:
+        process.env.ELEMENT_USER_AGENT || `element-cli/${ELEMENT_VERSION};`,
 };
 
 const authInformation: AuthConfig & AuthConstants = Object.assign(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -13,7 +13,7 @@ import {
     BUILT_FILE_PATH,
     USER_DEFINED_BLOCK_CONFIG_FILE,
 } from "../constants";
-import { isVerbose } from "../index";
+import { isVerbose, skipBuild } from "../index";
 import {
     checkErrorCode,
     createBlockRequest,
@@ -275,6 +275,10 @@ function getLatestMajorVersion(versions: any[]): number {
 }
 
 async function runBuild(): Promise<void> {
+    if (skipBuild) {
+        logInfo("Skipping npm build");
+        return;
+    }
     if (isVerbose) {
         logInfo("Running npm build");
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,9 @@
 import { homedir } from "os";
+import * as packageFile from "../package.json";
 
 export const BLOCK_SETTINGS_FILE = ".element-block";
 export const BUILT_FILE_PATH = "./dist/component.umd.js";
 export const RC_FILE_PATH = `${homedir()}/.volusionrc`;
 export const THUMBNAIL_PATH = "thumbnail.png";
 export const USER_DEFINED_BLOCK_CONFIG_FILE = "./dist/defaultConfig.json";
+export const ELEMENT_VERSION = packageFile.version;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
     rollback,
     update,
 } from "./commands/publish";
-import { BLOCK_SETTINGS_FILE } from "./constants";
+import { BLOCK_SETTINGS_FILE, ELEMENT_VERSION } from "./constants";
 import {
     getBlockRequest,
     getCategoryNames,
@@ -27,7 +27,7 @@ import {
 } from "./utils";
 
 program
-    .version("3.1.1", "-v, --version")
+    .version(ELEMENT_VERSION, "-v, --version")
     .usage(`[options] command`)
     .option("-V, --verbose", "Display verbose output")
     .description("Command line interface for the Volusion Element ecosystem");

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,13 @@ program
     .version(ELEMENT_VERSION, "-v, --version")
     .usage(`[options] command`)
     .option("-V, --verbose", "Display verbose output")
+    .option("-S, --skip-build", "Skip build")
     .description("Command line interface for the Volusion Element ecosystem");
 
 export const isVerbose =
     process.argv.includes("-V") || process.argv.includes("--verbose");
+export const skipBuild =
+    process.argv.includes("-S") || process.argv.includes("--skip-build");
 
 program
     .command("login")
@@ -302,7 +305,9 @@ program.on("command:*", () => {
 
 if (
     process.env.NODE_ENV !== "test" &&
-    (process.argv.length <= 2 || (isVerbose && process.argv.length === 3))
+    (process.argv.length <= 2 ||
+        (isVerbose && process.argv.length === 3) ||
+        (skipBuild && process.argv.length === 3))
 ) {
     program.outputHelp();
 } else {

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -33,6 +33,7 @@ const requestOptions = (
         Authorization: string;
         "Content-Type": string;
         "Element-Cli-Version": string;
+        "User-Agent": string;
     };
     method: HTTPVerbs;
     url: string;
@@ -46,6 +47,7 @@ const requestOptions = (
             Authorization: `Bearer ${getAppToken()}`,
             "Content-Type": "application/json",
             "Element-Cli-Version": packageFile.version,
+            "User-Agent": config.userAgent,
         },
         method,
         url,
@@ -230,7 +232,7 @@ export const rollbackBlockRequest = (
 export const getCategoryNames = async (): Promise<string[] | undefined> => {
     try {
         const url = `${config.blockRegistry.host}/categories`;
-        return await axios(requestOptions("GET", url)).then(
+        return axios(requestOptions("GET", url)).then(
             (categories: AxiosResponse) =>
                 categories.data.map(
                     (category: { id: string; name: string }) => category.name
@@ -264,5 +266,10 @@ export const loginRequest = (
         );
     }
 
-    return axios({ data, method: "POST", url: config.loginUrl });
+    return axios({
+        data,
+        headers: { "User-Agent": config.userAgent },
+        method: "POST",
+        url: config.loginUrl,
+    });
 };


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    + [ ] Tests for the changes have been added (for bug fixes / features)
    + [ ] Docs have been added / updated (for bug fixes / features)
    + [ ] Addresses [Github issue #n](https://github.com/volusion/element-cli/issues/n) (please replace `n` with the corresponding issue number -- no issue for this PR? You can create one [here](https://github.com/volusion/element-cli/issues/new) right quick! 🙏 )


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

minor feature

* **What is the current behavior?**

Autoruns npm build for publish, update, release 
Does not pass User-Agent

* **What is the new behavior (if this is a feature change)?**

Allow for a `--skip-build` switch for those using a different build system than npm
Passes header `User-Agent: element-cli/VERSION_NUMBER`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
