### PR TITLE
CHORE: Update Prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,59 +1253,6 @@
         }
       }
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -1479,7 +1426,7 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
@@ -1849,9 +1796,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "4.0.2",
+      "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
       "dev": true
     },
     "diff-sequences": {
@@ -1936,20 +1883,12 @@
     },
     "eslint-plugin-prettier": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
-      "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
+      "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
+      "integrity": "sha1-tDEtzywdllN51/nVtfiqrcakWQQ=",
       "dev": true,
       "requires": {
         "fast-diff": "^1.1.1",
         "jest-docblock": "^21.0.0"
-      },
-      "dependencies": {
-        "jest-docblock": {
-          "version": "21.2.0",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -2191,8 +2130,8 @@
     },
     "fast-diff": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha1-c+4RmC2Gyq95WYKNUZz+kn+sXwM=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -2408,23 +2347,6 @@
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        }
       }
     },
     "has-flag": {
@@ -4745,6 +4667,12 @@
         }
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
+      "dev": true
+    },
     "jest-get-type": {
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
@@ -4755,12 +4683,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
@@ -5502,9 +5424,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
-      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "version": "2.2.1",
+      "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha1-eVoaeN1S8HPaDNQrIfnJE4GSP/U=",
       "dev": true
     },
     "pretty-format": {
@@ -6750,24 +6672,32 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.1.tgz",
-      "integrity": "sha512-fplQqb2miLbcPhyHoMV4FU9PtNRbgmm/zI5d3SZwwmJQM6V0eodju+hplpyfhLWpmwrDNfNYU57uYRb8s0zZoQ==",
+      "version": "6.1.3",
+      "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha1-XCOy7MwySH1VI706Rw6aoxeJ2QQ=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
+        "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
-        "diff": "^3.2.0",
+        "diff": "^4.0.1",
         "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
+        "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "tslib": "^1.13.0",
+        "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+          "dev": true
+        }
       }
     },
     "tslint-config-prettier": {
@@ -6803,19 +6733,20 @@
       "dev": true
     },
     "tslint-plugin-prettier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
-      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "version": "2.3.0",
+      "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/tslint-plugin-prettier/-/tslint-plugin-prettier-2.3.0.tgz",
+      "integrity": "sha1-c/5xv58DhCrEjBBBIsqbHeAS7PQ=",
       "dev": true,
       "requires": {
         "eslint-plugin-prettier": "^2.2.0",
+        "lines-and-columns": "^1.1.6",
         "tslib": "^1.7.1"
       }
     },
     "tsutils": {
       "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "resolved": "https://volusion.jfrog.io/artifactory/api/npm/npm/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "husky": "^0.14.3",
     "jest": "^25.1.0",
     "mermaid.cli": "^0.5.1",
-    "prettier": "^1.14.0",
+    "prettier": "^2.2.1",
     "ts-jest": "^25.5.1",
-    "tslint": "^5.10.0",
+    "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.14.0",
     "tslint-microsoft-contrib": "^6.0.0",
     "tslint-no-focused-test": "^0.5.0",
-    "tslint-plugin-prettier": "^1.3.0",
+    "tslint-plugin-prettier": "^2.3.0",
     "typescript": "^3.8.3"
   },
   "scripts": {

--- a/src/commands/cloneBoilerplate.ts
+++ b/src/commands/cloneBoilerplate.ts
@@ -18,7 +18,7 @@ const BOILERPLATE_LOCATION =
     "https://github.com/volusion/element-BlockStarter.git";
 
 const removeStarterExtras = (toRemove: string[]): void => {
-    toRemove.forEach(name => {
+    toRemove.forEach((name) => {
         try {
             rimraf.sync(name);
         } catch (error) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -14,7 +14,7 @@ export const login = (username: string, password: string): Promise<void> => {
             logInfo(`Logged in as ${username}.`);
             exit(0);
         })
-        .catch(err => {
+        .catch((err) => {
             logError(`Problem with the login process: ${err.message}`);
             exit(1);
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ program
 program
     .command("new <name>")
     .description(`Create the block boilerplate`)
-    .action(name => {
+    .action((name) => {
         isLoggedInOrExit();
 
         cloneBoilerplate(name);
@@ -164,7 +164,7 @@ program
                 })
                 .then((confirmation: any) => {
                     if (confirmation.majorConfirmation) {
-                        newMajorVersion().catch(e => logError(e.message));
+                        newMajorVersion().catch((e) => logError(e.message));
                     } else {
                         exit(0);
                     }
@@ -192,7 +192,7 @@ program
                     })
                     .then((val: any) => {
                         const { categoryFromList } = val;
-                        publish(name, categoryFromList).catch(e =>
+                        publish(name, categoryFromList).catch((e) =>
                             logError(e.message)
                         );
                     });
@@ -228,7 +228,7 @@ program
     )
     .action(({ togglePublic, unminified, category }) => {
         isLoggedInOrExit();
-        update(togglePublic, unminified, category).catch(e =>
+        update(togglePublic, unminified, category).catch((e) =>
             logError(e.message)
         );
     });

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -21,4 +21,4 @@ export const toPascalCase = (input: string): string =>
                 `${letterAfterSpace.toUpperCase()}${restOfWord.toLowerCase()}`
         )
         .replace(new RegExp(/\s/, "g"), "")
-        .replace(new RegExp(/\w/), s => s.toUpperCase());
+        .replace(new RegExp(/\w/), (s) => s.toUpperCase());

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -131,9 +131,7 @@ export const getBlockRequest = (id: string, version?: number): AxiosPromise => {
     return axios(
         requestOptions(
             "GET",
-            `${
-                config.blockRegistry.host
-            }/blocks/${id}${optionalVersionQueryString}`
+            `${config.blockRegistry.host}/blocks/${id}${optionalVersionQueryString}`
         )
     );
 };
@@ -234,11 +232,12 @@ export const rollbackBlockRequest = (
 export const getCategoryNames = async (): Promise<string[] | undefined> => {
     try {
         const url = `${config.blockRegistry.host}/categories`;
-        return axios(requestOptions("GET", url)).then(
-            (categories: AxiosResponse) =>
-                categories.data.map(
-                    (category: { id: string; name: string }) => category.name
-                )
+        return axios(
+            requestOptions("GET", url)
+        ).then((categories: AxiosResponse) =>
+            categories.data.map(
+                (category: { id: string; name: string }) => category.name
+            )
         );
     } catch (err) {
         logError(`Trouble reaching the categories service: ${err.message}`);

--- a/tslint.json
+++ b/tslint.json
@@ -20,13 +20,9 @@
             "check-format",
             "allow-leading-underscore"
         ],
-        "interface-name": [
-            true,
-            "never-prefix"
-        ],
+        "interface-name": [true, "never-prefix"],
         "typedef": [
             true,
-            "arrow-call-signature",
             "call-signature",
             "parameter",
             "member-variable-declaration"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    + [ ] Tests for the changes have been added (for bug fixes / features)
    + [ ] Docs have been added / updated (for bug fixes / features)
    + [ ] Addresses a Github issue

N/A for all of these; it's just a quick tooling upgrade.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Updates Prettier and TSLint so that it can understand newer syntax.

* **What is the current behavior?**

TSLint can fail on, and skip, an entire file if syntax features such as [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) are used. In several of those files, a number of `typedef/arrow-call-signature` errors snuck in.

* **What is the new behavior (if this is a feature change)?**

TSLint now supports all the new stuff. Also removed the `typedef/arrow-call-signature` rule since there were a number of existing violations and, in my opinion, it's unnecessarily strict.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No; even if new language features were to be used in future PRs, TypeScript would compile it to more broadly supported syntax.