### PR TITLE
Add cache duration option to publish and update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # Default reviewers for everything in the repo.
 # Unless a later match takes precedence "*" = all
 
-* @chris-decker-volusion @greg-murray-volusion @cameron-jones-volusion @divinentd
+* @greg-murray-volusion @divinentd @avery-milandin-volusion @gjritter @dgritter @chris-ruzin-volusion @samscha-volusion @dallonf @prabinv

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.2.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-cli",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Command line interface for the Volusion Element ecosystem",
   "author": "Volusion, LLC",
   "main": "bin/src/index.js",

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -31,21 +31,28 @@ import {
     validateCategory,
     validateInputs,
 } from "../utils";
-import { integrationIdFromName } from "../utils/validation";
+import {
+    integrationIdFromName,
+    validateCacheDuration,
+} from "../utils/validation";
 
 const publish = async ({
     name,
     category,
     categories,
     integrationName,
+    cacheDuration,
 }: {
     name: string | null;
     category: string;
     categories?: string[];
     integrationName?: string;
+    cacheDuration: string;
 }): Promise<void> => {
     validateBlockDirectory();
     await runBuild();
+
+    const outputCacheDuration = Number(cacheDuration);
 
     const {
         displayName,
@@ -57,6 +64,7 @@ const publish = async ({
         category,
         integrationName,
         name,
+        cacheDuration: outputCacheDuration,
     });
     const filePath = resolve(cwd(), BUILT_FILE_PATH);
     const blockData = readFileSync(filePath).toString();
@@ -74,6 +82,7 @@ const publish = async ({
                 displayName,
                 publishedName,
             },
+            outputCacheDuration,
         });
 
         logResponse(res);
@@ -88,6 +97,7 @@ const publish = async ({
             integrationId: res.data.integrationId,
             isPublic: false,
             published: true,
+            outputCacheDuration,
         });
 
         logSuccess(`
@@ -142,11 +152,13 @@ const newMajorVersion = async (): Promise<void> => {
 };
 
 const update = async ({
+    cacheDuration,
     togglePublic,
     unminified,
     updatedCategory,
     updatedIntegration,
 }: {
+    cacheDuration: string;
     togglePublic: boolean;
     unminified: boolean;
     updatedCategory: string | undefined;
@@ -154,6 +166,10 @@ const update = async ({
 }): Promise<void> => {
     validateBlockDirectory();
     validateBlockPublished();
+    if (cacheDuration !== undefined) {
+        logInfo(`cacheDuration: ${cacheDuration}`);
+        validateCacheDuration(Number(cacheDuration));
+    }
     await runBuild();
 
     const filePath = resolve(cwd(), BUILT_FILE_PATH);
@@ -168,6 +184,7 @@ const update = async ({
         id,
         isPublic,
         publishedName,
+        outputCacheDuration,
     } = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
 
     const publicFlag = togglePublic ? !isPublic : isPublic;
@@ -179,6 +196,10 @@ const update = async ({
 
     const integrationId = integrationIdFromName(updatedIntegration);
 
+    const newCacheDuration =
+        cacheDuration === undefined
+            ? outputCacheDuration
+            : Number(cacheDuration);
     try {
         const res: AxiosResponse = await updateBlockRequest({
             defaultConfig,
@@ -189,6 +210,7 @@ const update = async ({
             version,
             category: updatedCategory || currentCategory,
             integrationId,
+            outputCacheDuration: newCacheDuration,
         });
 
         logResponse(res);
@@ -199,6 +221,7 @@ const update = async ({
             integrationId: res.data.integrationId,
             isPublic: publicFlag,
             published: true,
+            outputCacheDuration: newCacheDuration,
         });
 
         logSuccess(`

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -47,7 +47,7 @@ const publish = async ({
     category: string;
     categories?: string[];
     integrationName?: string;
-    cacheDuration: string;
+    cacheDuration: string | undefined;
 }): Promise<void> => {
     validateBlockDirectory();
     await runBuild();
@@ -158,7 +158,7 @@ const update = async ({
     updatedCategory,
     updatedIntegration,
 }: {
-    cacheDuration: string;
+    cacheDuration: string | undefined;
     togglePublic: boolean;
     unminified: boolean;
     updatedCategory: string | undefined;
@@ -167,7 +167,6 @@ const update = async ({
     validateBlockDirectory();
     validateBlockPublished();
     if (cacheDuration !== undefined) {
-        logInfo(`cacheDuration: ${cacheDuration}`);
         validateCacheDuration(Number(cacheDuration));
     }
     await runBuild();

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -14,6 +14,7 @@ export interface BlockFileObject {
     published?: boolean; // Since v.2.0.8
     activeVersion?: number;
     integrationId?: number;
+    outputCacheDuration: number;
 }
 
 type UpdateData = Partial<BlockFileObject>;

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -66,6 +66,7 @@ const buildRequestConfig = ({
     defaultConfig,
     note = "",
     integrationId,
+    outputCacheDuration,
 }: {
     category?: string;
     fileData: string;
@@ -81,6 +82,7 @@ const buildRequestConfig = ({
     defaultConfig: { [key: string]: any };
     note?: string;
     integrationId: number | undefined;
+    outputCacheDuration: number;
 }): AxiosRequestConfig => {
     const options = requestOptions(method as HTTPVerbs, url);
     const thumbnail = prepareImage(THUMBNAIL_PATH);
@@ -99,6 +101,7 @@ const buildRequestConfig = ({
                 note,
                 thumbnail,
             },
+            outputCacheDuration,
             version,
         },
     };
@@ -146,6 +149,7 @@ export const createBlockRequest = ({
     fileData,
     category,
     integrationId,
+    outputCacheDuration,
 }: {
     defaultConfig: { [key: string]: any };
     id: string;
@@ -156,6 +160,7 @@ export const createBlockRequest = ({
     fileData: string;
     category: string;
     integrationId: number | undefined;
+    outputCacheDuration: number;
 }): AxiosPromise =>
     axios(
         buildRequestConfig({
@@ -167,6 +172,7 @@ export const createBlockRequest = ({
             method: "POST",
             names,
             url: `${config.blockRegistry.host}/blocks`,
+            outputCacheDuration,
         })
     );
 
@@ -179,6 +185,7 @@ export const updateBlockRequest = ({
     version,
     category,
     integrationId,
+    outputCacheDuration,
 }: {
     defaultConfig: { [key: string]: any };
     names: {
@@ -191,6 +198,7 @@ export const updateBlockRequest = ({
     version: number;
     category: string | undefined;
     integrationId: number | undefined;
+    outputCacheDuration: number;
 }): AxiosPromise =>
     axios(
         buildRequestConfig({
@@ -203,6 +211,7 @@ export const updateBlockRequest = ({
             url: `${config.blockRegistry.host}/blocks/${id}`,
             version,
             integrationId,
+            outputCacheDuration,
         })
     );
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -38,11 +38,13 @@ export const validateInputs = async ({
     category,
     categories,
     integrationName,
+    cacheDuration,
 }: {
     name: string | null;
     category: string;
     categories?: string[];
     integrationName: string | undefined;
+    cacheDuration: number | undefined;
 }): Promise<{
     displayName: string;
     publishedName: string;
@@ -68,6 +70,10 @@ export const validateInputs = async ({
         .displayName;
     const displayName = formatName(name || nameFromDotFile);
     const { publishedName, id } = readBlockSettingsFile(BLOCK_SETTINGS_FILE);
+
+    if (cacheDuration !== undefined) {
+        validateCacheDuration(cacheDuration);
+    }
 
     return { displayName, publishedName, id, integrationId };
 };
@@ -110,3 +116,15 @@ export const integrationIdFromName = (
     }
     return integration.id;
 };
+
+export function validateCacheDuration(cacheDuration: number): void {
+    if (
+        typeof cacheDuration !== "number" ||
+        Number.isNaN(cacheDuration) ||
+        cacheDuration < 0 ||
+        !Number.isInteger(cacheDuration)
+    ) {
+        logError("Cache duration must be a positive integer or zero.");
+        exit(1);
+    }
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    + [ ] Tests for the changes have been added (for bug fixes / features)
    + [X] Docs have been added / updated (for bug fixes / features)
    + [ ] Addresses [Github issue #n](https://github.com/volusion/element-cli/issues/n) (please replace `n` with the corresponding issue number -- no issue for this PR? You can create one [here](https://github.com/volusion/element-cli/issues/new) right quick! 🙏 )


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature: adds a new `--cache-duration=n` option for `publish` and `update` to allow block authors to specify the duration (in seconds) for which `getDataProps` results will be cached.

* **What is the current behavior?**

Blocks' `getDataProps` results are not cached, and cache duration cannot be specified.

* **What is the new behavior (if this is a feature change)?**

A cache duration (in seconds) can be specified using the `--cache-duration=n` option for the `publish` and `update` commands.

A cache duration of 0 can be used to specify that `getDataProps` results will not be cached.

When publishing, omitting `--cache-duration` will cause the cache duration to be 0.

When updating, omitting `--cache-duration` will cause the block's previous cache duration to be used.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
